### PR TITLE
update oras version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     services:
       oci-registry:
-        image: ghcr.io/project-zot/zot-minimal-linux-amd64:v1.4.3-rc7
+        image: ghcr.io/project-zot/zot-minimal-linux-amd64:latest
         ports:
           - 5000:5000
     steps:
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install oras
         run: |
-          ORAS_VERSION=0.15.1
+          ORAS_VERSION=0.16.0
           curl -Lo oras.tar.gz https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz
           tar -zxf oras.tar.gz oras
           mv oras /usr/local/bin/oras


### PR DESCRIPTION
# Description

`zot` latest should never break this contract.

`oras` v0.16.0 works as expected, hence updating the version.

# Pipelines

_**if applicable**, please complete checklist_
- [ ] Link(s) to or screenshot(s) of successful pipeline runs and the expected result (ie. the output of `oras discover -o tree $IMAGE`)
- [*] Verify & confirm the following:
  - [*] New functionality works as expected
  - [*] No breaking changes were introduced for existing pipelines

```
$ ./oras version
Version:        0.16.0
Go version:     go1.19.2
Git commit:     d606fed4be252fd6162f63548e024451c31f3864
Git tree state: clean

$ ./notation -v
notation version 0.11.0-alpha.4

$ ./notation sign --plain-http --envelope-type cose --media-type application/vnd.docker.distribution.manifest.v2+json localhost:8080/alpine:edge
sha256:77ee9d7d39229024fd77373e079e03f3a6d384044391a0f9ae1d1f115aa38e8e

$ ./oras discover localhost:8080/alpine:edge -o tree
localhost:8080/alpine:edge

$ ./oras attach localhost:8080/alpine:edge     --artifact-type 'signature/example'      ./signature.json:application/json
Uploading b5334d78ecfc signature.json
Uploaded  b5334d78ecfc signature.json
Attached to localhost:8080/alpine@sha256:77ee9d7d39229024fd77373e079e03f3a6d384044391a0f9ae1d1f115aa38e8e
Digest: sha256:46909d1875cbe65ba8b760056d6ee337803c551f515403b89088a699ee89a309

$ ./oras discover localhost:8080/alpine:edge -o tree
localhost:8080/alpine:edge
└── signature/example
    └── sha256:46909d1875cbe65ba8b760056d6ee337803c551f515403b89088a699ee89a309
```



# Related Work Item(s)

_Link to AzDO user story. Linking to tasks is optional, but use your judgment re: what items are resolved by the PR._